### PR TITLE
Options: Height to Width Ratio

### DIFF
--- a/js/jquery.gridrotator.js
+++ b/js/jquery.gridrotator.js
@@ -300,7 +300,7 @@
 
 					$item.css( {
 						width : j < Math.floor( gapWidth ) ? itemWidth + 1 : itemWidth,
-						height : itemWidth*this.options.heightToWidthRatio
+						height : Math.floor( itemWidth * this.options.heightToWidthRatio )
 					} );
 
 					if( $.inArray( idx, this.options.nochange ) !== -1 ) {


### PR DESCRIPTION
Added a Height to Width Ratio to the list of options (Width/Height). A 0.5 ratio would be used for an image that is twice as large as it's height. Default is 1 (square images). I guess we could switch it around (Height/Width (?)). I don't really mind. As long as we can use non-square thumbnails..!

I think this jQuery plugin is great but this really simple change would make it even better IMO.
